### PR TITLE
Remove the word Upozzilla from English Upozilla names

### DIFF
--- a/bd-upazilas.json
+++ b/bd-upazilas.json
@@ -3,211 +3,211 @@
     {
       "id": "1",
       "district_id": "34",
-      "name": "Amtali Upazila",
+      "name": "Amtali",
       "bn_name": "আমতলী"
     },
     {
       "id": "2",
       "district_id": "34",
-      "name": "Bamna Upazila",
+      "name": "Bamna",
       "bn_name": "বামনা"
     },
     {
       "id": "3",
       "district_id": "34",
-      "name": "Barguna Sadar Upazila",
+      "name": "Barguna Sadar",
       "bn_name": "বরগুনা সদর"
     },
     {
       "id": "4",
       "district_id": "34",
-      "name": "Betagi Upazila",
+      "name": "Betagi",
       "bn_name": "বেতাগি"
     },
     {
       "id": "5",
       "district_id": "34",
-      "name": "Patharghata Upazila",
+      "name": "Patharghata",
       "bn_name": "পাথরঘাটা"
     },
     {
       "id": "6",
       "district_id": "34",
-      "name": "Taltali Upazila",
+      "name": "Taltali",
       "bn_name": "তালতলী"
     },
     {
       "id": "7",
       "district_id": "35",
-      "name": "Muladi Upazila",
+      "name": "Muladi",
       "bn_name": "মুলাদি"
     },
     {
       "id": "8",
       "district_id": "35",
-      "name": "Babuganj Upazila",
+      "name": "Babuganj",
       "bn_name": "বাবুগঞ্জ"
     },
     {
       "id": "9",
       "district_id": "35",
-      "name": "Agailjhara Upazila",
+      "name": "Agailjhara",
       "bn_name": "আগাইলঝরা"
     },
     {
       "id": "10",
       "district_id": "35",
-      "name": "Barisal Sadar Upazila",
+      "name": "Barisal Sadar",
       "bn_name": "বরিশাল সদর"
     },
     {
       "id": "11",
       "district_id": "35",
-      "name": "Bakerganj Upazila",
+      "name": "Bakerganj",
       "bn_name": "বাকেরগঞ্জ"
     },
     {
       "id": "12",
       "district_id": "35",
-      "name": "Banaripara Upazila",
+      "name": "Banaripara",
       "bn_name": "বানাড়িপারা"
     },
     {
       "id": "13",
       "district_id": "35",
-      "name": "Gaurnadi Upazila",
+      "name": "Gaurnadi",
       "bn_name": "গৌরনদী"
     },
     {
       "id": "14",
       "district_id": "35",
-      "name": "Hizla Upazila",
+      "name": "Hizla",
       "bn_name": "হিজলা"
     },
     {
       "id": "15",
       "district_id": "35",
-      "name": "Mehendiganj Upazila",
+      "name": "Mehendiganj",
       "bn_name": "মেহেদিগঞ্জ "
     },
     {
       "id": "16",
       "district_id": "35",
-      "name": "Wazirpur Upazila",
+      "name": "Wazirpur",
       "bn_name": "ওয়াজিরপুর"
     },
     {
       "id": "17",
       "district_id": "36",
-      "name": "Bhola Sadar Upazila",
+      "name": "Bhola Sadar",
       "bn_name": "ভোলা সদর"
     },
     {
       "id": "18",
       "district_id": "36",
-      "name": "Burhanuddin Upazila",
+      "name": "Burhanuddin",
       "bn_name": "বুরহানউদ্দিন"
     },
     {
       "id": "19",
       "district_id": "36",
-      "name": "Char Fasson Upazila",
+      "name": "Char Fasson",
       "bn_name": "চর ফ্যাশন"
     },
     {
       "id": "20",
       "district_id": "36",
-      "name": "Daulatkhan Upazila",
+      "name": "Daulatkhan",
       "bn_name": "দৌলতখান"
     },
     {
       "id": "21",
       "district_id": "36",
-      "name": "Lalmohan Upazila",
+      "name": "Lalmohan",
       "bn_name": "লালমোহন"
     },
     {
       "id": "22",
       "district_id": "36",
-      "name": "Manpura Upazila",
+      "name": "Manpura",
       "bn_name": "মনপুরা"
     },
     {
       "id": "23",
       "district_id": "36",
-      "name": "Tazumuddin Upazila",
+      "name": "Tazumuddin",
       "bn_name": "তাজুমুদ্দিন"
     },
     {
       "id": "24",
       "district_id": "37",
-      "name": "Jhalokati Sadar Upazila",
+      "name": "Jhalokati Sadar",
       "bn_name": "ঝালকাঠি সদর"
     },
     {
       "id": "25",
       "district_id": "37",
-      "name": "Kathalia Upazila",
+      "name": "Kathalia",
       "bn_name": "কাঁঠালিয়া"
     },
     {
       "id": "26",
       "district_id": "37",
-      "name": "Nalchity Upazila",
+      "name": "Nalchity",
       "bn_name": "নালচিতি"
     },
     {
       "id": "27",
       "district_id": "37",
-      "name": "Rajapur Upazila",
+      "name": "Rajapur",
       "bn_name": "রাজাপুর"
     },
     {
       "id": "28",
       "district_id": "38",
-      "name": "Bauphal Upazila",
+      "name": "Bauphal",
       "bn_name": "বাউফল"
     },
     {
       "id": "29",
       "district_id": "38",
-      "name": "Dashmina Upazila",
+      "name": "Dashmina",
       "bn_name": "দশমিনা"
     },
     {
       "id": "30",
       "district_id": "38",
-      "name": "Galachipa Upazila",
+      "name": "Galachipa",
       "bn_name": "গলাচিপা"
     },
     {
       "id": "31",
       "district_id": "38",
-      "name": "Kalapara Upazila",
+      "name": "Kalapara",
       "bn_name": "কালাপারা"
     },
     {
       "id": "32",
       "district_id": "38",
-      "name": "Mirzaganj Upazila",
+      "name": "Mirzaganj",
       "bn_name": "মির্জাগঞ্জ "
     },
     {
       "id": "33",
       "district_id": "38",
-      "name": "Patuakhali Sadar Upazila",
+      "name": "Patuakhali Sadar",
       "bn_name": "পটুয়াখালী সদর"
     },
     {
       "id": "34",
       "district_id": "38",
-      "name": "Dumki Upazila",
+      "name": "Dumki",
       "bn_name": "ডুমকি"
     },
     {
       "id": "35",
       "district_id": "38",
-      "name": "Rangabali Upazila",
+      "name": "Rangabali",
       "bn_name": "রাঙ্গাবালি"
     },
     {
@@ -297,31 +297,31 @@
     {
       "id": "50",
       "district_id": "41",
-      "name": "Brahmanbaria Sadar Upazila",
+      "name": "Brahmanbaria Sadar",
       "bn_name": "ব্রাহ্মণবাড়িয়া সদর"
     },
     {
       "id": "51",
       "district_id": "41",
-      "name": "Ashuganj Upazila",
+      "name": "Ashuganj",
       "bn_name": "আশুগঞ্জ"
     },
     {
       "id": "52",
       "district_id": "41",
-      "name": "Nasirnagar Upazila",
+      "name": "Nasirnagar",
       "bn_name": "নাসির নগর"
     },
     {
       "id": "53",
       "district_id": "41",
-      "name": "Nabinagar Upazila",
+      "name": "Nabinagar",
       "bn_name": "নবীনগর"
     },
     {
       "id": "54",
       "district_id": "41",
-      "name": "Sarail Upazila",
+      "name": "Sarail",
       "bn_name": "সরাইল"
     },
     {
@@ -333,25 +333,25 @@
     {
       "id": "56",
       "district_id": "41",
-      "name": "Kasba Upazila",
+      "name": "Kasba",
       "bn_name": "কসবা"
     },
     {
       "id": "57",
       "district_id": "41",
-      "name": "Akhaura Upazila",
+      "name": "Akhaura",
       "bn_name": "আখাউরা"
     },
     {
       "id": "58",
       "district_id": "41",
-      "name": "Bancharampur Upazila",
+      "name": "Bancharampur",
       "bn_name": "বাঞ্ছারামপুর"
     },
     {
       "id": "59",
       "district_id": "41",
-      "name": "Bijoynagar Upazila",
+      "name": "Bijoynagar",
       "bn_name": "বিজয় নগর"
     },
     {
@@ -405,187 +405,187 @@
     {
       "id": "68",
       "district_id": "43",
-      "name": "Anwara Upazila",
+      "name": "Anwara",
       "bn_name": "আনোয়ারা"
     },
     {
       "id": "69",
       "district_id": "43",
-      "name": "Banshkhali Upazila",
+      "name": "Banshkhali",
       "bn_name": "বাশখালি"
     },
     {
       "id": "70",
       "district_id": "43",
-      "name": "Boalkhali Upazila",
+      "name": "Boalkhali",
       "bn_name": "বোয়ালখালি"
     },
     {
       "id": "71",
       "district_id": "43",
-      "name": "Chandanaish Upazila",
+      "name": "Chandanaish",
       "bn_name": "চন্দনাইশ"
     },
     {
       "id": "72",
       "district_id": "43",
-      "name": "Fatikchhari Upazila",
+      "name": "Fatikchhari",
       "bn_name": "ফটিকছড়ি"
     },
     {
       "id": "73",
       "district_id": "43",
-      "name": "Hathazari Upazila",
+      "name": "Hathazari",
       "bn_name": "হাঠহাজারী"
     },
     {
       "id": "74",
       "district_id": "43",
-      "name": "Lohagara Upazila",
+      "name": "Lohagara",
       "bn_name": "লোহাগারা"
     },
     {
       "id": "75",
       "district_id": "43",
-      "name": "Mirsharai Upazila",
+      "name": "Mirsharai",
       "bn_name": "মিরসরাই"
     },
     {
       "id": "76",
       "district_id": "43",
-      "name": "Patiya Upazila",
+      "name": "Patiya",
       "bn_name": "পটিয়া"
     },
     {
       "id": "77",
       "district_id": "43",
-      "name": "Rangunia Upazila",
+      "name": "Rangunia",
       "bn_name": "রাঙ্গুনিয়া"
     },
     {
       "id": "78",
       "district_id": "43",
-      "name": "Raozan Upazila",
+      "name": "Raozan",
       "bn_name": "রাউজান"
     },
     {
       "id": "79",
       "district_id": "43",
-      "name": "Sandwip Upazila",
+      "name": "Sandwip",
       "bn_name": "সন্দ্বীপ"
     },
     {
       "id": "80",
       "district_id": "43",
-      "name": "Satkania Upazila",
+      "name": "Satkania",
       "bn_name": "সাতকানিয়া"
     },
     {
       "id": "81",
       "district_id": "43",
-      "name": "Sitakunda Upazila",
+      "name": "Sitakunda",
       "bn_name": "সীতাকুণ্ড"
     },
     {
       "id": "82",
       "district_id": "44",
-      "name": "Barura Upazila",
+      "name": "Barura",
       "bn_name": "বড়ুরা"
     },
     {
       "id": "83",
       "district_id": "44",
-      "name": "Brahmanpara Upazila",
+      "name": "Brahmanpara",
       "bn_name": "ব্রাহ্মণপাড়া"
     },
     {
       "id": "84",
       "district_id": "44",
-      "name": "Burichong Upazila",
+      "name": "Burichong",
       "bn_name": "বুড়িচং"
     },
     {
       "id": "85",
       "district_id": "44",
-      "name": "Chandina Upazila",
+      "name": "Chandina",
       "bn_name": "চান্দিনা"
     },
     {
       "id": "86",
       "district_id": "44",
-      "name": "Chauddagram Upazila",
+      "name": "Chauddagram",
       "bn_name": "চৌদ্দগ্রাম"
     },
     {
       "id": "87",
       "district_id": "44",
-      "name": "Daudkandi Upazila",
+      "name": "Daudkandi",
       "bn_name": "দাউদকান্দি"
     },
     {
       "id": "88",
       "district_id": "44",
-      "name": "Debidwar Upazila",
+      "name": "Debidwar",
       "bn_name": "দেবীদ্বার"
     },
     {
       "id": "89",
       "district_id": "44",
-      "name": "Homna Upazila",
+      "name": "Homna",
       "bn_name": "হোমনা"
     },
     {
       "id": "90",
       "district_id": "44",
-      "name": "Comilla Sadar Upazila",
+      "name": "Comilla Sadar",
       "bn_name": "কুমিল্লা সদর"
     },
     {
       "id": "91",
       "district_id": "44",
-      "name": "Laksam Upazila",
+      "name": "Laksam",
       "bn_name": "লাকসাম"
     },
     {
       "id": "92",
       "district_id": "44",
-      "name": "Monohorgonj Upazila",
+      "name": "Monohorgonj",
       "bn_name": "মনোহরগঞ্জ"
     },
     {
       "id": "93",
       "district_id": "44",
-      "name": "Meghna Upazila",
+      "name": "Meghna",
       "bn_name": "মেঘনা"
     },
     {
       "id": "94",
       "district_id": "44",
-      "name": "Muradnagar Upazila",
+      "name": "Muradnagar",
       "bn_name": "মুরাদনগর"
     },
     {
       "id": "95",
       "district_id": "44",
-      "name": "Nangalkot Upazila",
+      "name": "Nangalkot",
       "bn_name": "নাঙ্গালকোট"
     },
     {
       "id": "96",
       "district_id": "44",
-      "name": "Comilla Sadar South Upazila",
+      "name": "Comilla Sadar South",
       "bn_name": "কুমিল্লা সদর দক্ষিণ"
     },
     {
       "id": "97",
       "district_id": "44",
-      "name": "Titas Upazila",
+      "name": "Titas",
       "bn_name": "তিতাস"
     },
     {
       "id": "98",
       "district_id": "45",
-      "name": "Chakaria Upazila",
+      "name": "Chakaria",
       "bn_name": "চকরিয়া"
     },
     {
@@ -597,37 +597,37 @@
     {
       "id": "101",
       "district_id": "45",
-      "name": "Kutubdia Upazila",
+      "name": "Kutubdia",
       "bn_name": "কুতুবদিয়া"
     },
     {
       "id": "102",
       "district_id": "45",
-      "name": "Maheshkhali Upazila",
+      "name": "Maheshkhali",
       "bn_name": "মহেশখালী"
     },
     {
       "id": "103",
       "district_id": "45",
-      "name": "Ramu Upazila",
+      "name": "Ramu",
       "bn_name": "রামু"
     },
     {
       "id": "104",
       "district_id": "45",
-      "name": "Teknaf Upazila",
+      "name": "Teknaf",
       "bn_name": "টেকনাফ"
     },
     {
       "id": "105",
       "district_id": "45",
-      "name": "Ukhia Upazila",
+      "name": "Ukhia",
       "bn_name": "উখিয়া"
     },
     {
       "id": "106",
       "district_id": "45",
-      "name": "Pekua Upazila",
+      "name": "Pekua",
       "bn_name": "পেকুয়া"
     },
     {
@@ -669,277 +669,277 @@
     {
       "id": "113",
       "district_id": "47",
-      "name": "Dighinala Upazila",
+      "name": "Dighinala",
       "bn_name": "দিঘিনালা "
     },
     {
       "id": "114",
       "district_id": "47",
-      "name": "Khagrachhari Upazila",
+      "name": "Khagrachhari",
       "bn_name": "খাগড়াছড়ি"
     },
     {
       "id": "115",
       "district_id": "47",
-      "name": "Lakshmichhari Upazila",
+      "name": "Lakshmichhari",
       "bn_name": "লক্ষ্মীছড়ি"
     },
     {
       "id": "116",
       "district_id": "47",
-      "name": "Mahalchhari Upazila",
+      "name": "Mahalchhari",
       "bn_name": "মহলছড়ি"
     },
     {
       "id": "117",
       "district_id": "47",
-      "name": "Manikchhari Upazila",
+      "name": "Manikchhari",
       "bn_name": "মানিকছড়ি"
     },
     {
       "id": "118",
       "district_id": "47",
-      "name": "Matiranga Upazila",
+      "name": "Matiranga",
       "bn_name": "মাটিরাঙ্গা"
     },
     {
       "id": "119",
       "district_id": "47",
-      "name": "Panchhari Upazila",
+      "name": "Panchhari",
       "bn_name": "পানছড়ি"
     },
     {
       "id": "120",
       "district_id": "47",
-      "name": "Ramgarh Upazila",
+      "name": "Ramgarh",
       "bn_name": "রামগড়"
     },
     {
       "id": "121",
       "district_id": "48",
-      "name": "Lakshmipur Sadar Upazila",
+      "name": "Lakshmipur Sadar",
       "bn_name": "লক্ষ্মীপুর সদর"
     },
     {
       "id": "122",
       "district_id": "48",
-      "name": "Raipur Upazila",
+      "name": "Raipur",
       "bn_name": "রায়পুর"
     },
     {
       "id": "123",
       "district_id": "48",
-      "name": "Ramganj Upazila",
+      "name": "Ramganj",
       "bn_name": "রামগঞ্জ"
     },
     {
       "id": "124",
       "district_id": "48",
-      "name": "Ramgati Upazila",
+      "name": "Ramgati",
       "bn_name": "রামগতি"
     },
     {
       "id": "125",
       "district_id": "48",
-      "name": "Komol Nagar Upazila",
+      "name": "Komol Nagar",
       "bn_name": "কমল নগর"
     },
     {
       "id": "126",
       "district_id": "49",
-      "name": "Noakhali Sadar Upazila",
+      "name": "Noakhali Sadar",
       "bn_name": "নোয়াখালী সদর"
     },
     {
       "id": "127",
       "district_id": "49",
-      "name": "Begumganj Upazila",
+      "name": "Begumganj",
       "bn_name": "বেগমগঞ্জ"
     },
     {
       "id": "128",
       "district_id": "49",
-      "name": "Chatkhil Upazila",
+      "name": "Chatkhil",
       "bn_name": "চাটখিল"
     },
     {
       "id": "129",
       "district_id": "49",
-      "name": "Companyganj Upazila",
+      "name": "Companyganj",
       "bn_name": "কোম্পানীগঞ্জ"
     },
     {
       "id": "130",
       "district_id": "49",
-      "name": "Shenbag Upazila",
+      "name": "Shenbag",
       "bn_name": "শেনবাগ"
     },
     {
       "id": "131",
       "district_id": "49",
-      "name": "Hatia Upazila",
+      "name": "Hatia",
       "bn_name": "হাতিয়া"
     },
     {
       "id": "132",
       "district_id": "49",
-      "name": "Kobirhat Upazila",
+      "name": "Kobirhat",
       "bn_name": "কবিরহাট "
     },
     {
       "id": "133",
       "district_id": "49",
-      "name": "Sonaimuri Upazila",
+      "name": "Sonaimuri",
       "bn_name": "সোনাইমুরি"
     },
     {
       "id": "134",
       "district_id": "49",
-      "name": "Suborno Char Upazila",
+      "name": "Suborno Char",
       "bn_name": "সুবর্ণ চর "
     },
     {
       "id": "135",
       "district_id": "50",
-      "name": "Rangamati Sadar Upazila",
+      "name": "Rangamati Sadar",
       "bn_name": "রাঙ্গামাটি সদর"
     },
     {
       "id": "136",
       "district_id": "50",
-      "name": "Belaichhari Upazila",
+      "name": "Belaichhari",
       "bn_name": "বেলাইছড়ি"
     },
     {
       "id": "137",
       "district_id": "50",
-      "name": "Bagaichhari Upazila",
+      "name": "Bagaichhari",
       "bn_name": "বাঘাইছড়ি"
     },
     {
       "id": "138",
       "district_id": "50",
-      "name": "Barkal Upazila",
+      "name": "Barkal",
       "bn_name": "বরকল"
     },
     {
       "id": "139",
       "district_id": "50",
-      "name": "Juraichhari Upazila",
+      "name": "Juraichhari",
       "bn_name": "জুরাইছড়ি"
     },
     {
       "id": "140",
       "district_id": "50",
-      "name": "Rajasthali Upazila",
+      "name": "Rajasthali",
       "bn_name": "রাজাস্থলি"
     },
     {
       "id": "141",
       "district_id": "50",
-      "name": "Kaptai Upazila",
+      "name": "Kaptai",
       "bn_name": "কাপ্তাই"
     },
     {
       "id": "142",
       "district_id": "50",
-      "name": "Langadu Upazila",
+      "name": "Langadu",
       "bn_name": "লাঙ্গাডু"
     },
     {
       "id": "143",
       "district_id": "50",
-      "name": "Nannerchar Upazila",
+      "name": "Nannerchar",
       "bn_name": "নান্নেরচর "
     },
     {
       "id": "144",
       "district_id": "50",
-      "name": "Kaukhali Upazila",
+      "name": "Kaukhali",
       "bn_name": "কাউখালি"
     },
     {
       "id": "145",
       "district_id": "1",
-      "name": "Dhamrai Upazila",
+      "name": "Dhamrai",
       "bn_name": "ধামরাই"
     },
     {
       "id": "146",
       "district_id": "1",
-      "name": "Dohar Upazila",
+      "name": "Dohar",
       "bn_name": "দোহার"
     },
     {
       "id": "147",
       "district_id": "1",
-      "name": "Keraniganj Upazila",
+      "name": "Keraniganj",
       "bn_name": "কেরানীগঞ্জ"
     },
     {
       "id": "148",
       "district_id": "1",
-      "name": "Nawabganj Upazila",
+      "name": "Nawabganj",
       "bn_name": "নবাবগঞ্জ"
     },
     {
       "id": "149",
       "district_id": "1",
-      "name": "Savar Upazila",
+      "name": "Savar",
       "bn_name": "সাভার"
     },
     {
       "id": "150",
       "district_id": "2",
-      "name": "Faridpur Sadar Upazila",
+      "name": "Faridpur Sadar",
       "bn_name": "ফরিদপুর সদর"
     },
     {
       "id": "151",
       "district_id": "2",
-      "name": "Boalmari Upazila",
+      "name": "Boalmari",
       "bn_name": "বোয়ালমারী"
     },
     {
       "id": "152",
       "district_id": "2",
-      "name": "Alfadanga Upazila",
+      "name": "Alfadanga",
       "bn_name": "আলফাডাঙ্গা"
     },
     {
       "id": "153",
       "district_id": "2",
-      "name": "Madhukhali Upazila",
+      "name": "Madhukhali",
       "bn_name": "মধুখালি"
     },
     {
       "id": "154",
       "district_id": "2",
-      "name": "Bhanga Upazila",
+      "name": "Bhanga",
       "bn_name": "ভাঙ্গা"
     },
     {
       "id": "155",
       "district_id": "2",
-      "name": "Nagarkanda Upazila",
+      "name": "Nagarkanda",
       "bn_name": "নগরকান্ড"
     },
     {
       "id": "156",
       "district_id": "2",
-      "name": "Charbhadrasan Upazila",
+      "name": "Charbhadrasan",
       "bn_name": "চরভদ্রাসন "
     },
     {
       "id": "157",
       "district_id": "2",
-      "name": "Sadarpur Upazila",
+      "name": "Sadarpur",
       "bn_name": "সদরপুর"
     },
     {
       "id": "158",
       "district_id": "2",
-      "name": "Shaltha Upazila",
+      "name": "Shaltha",
       "bn_name": "শালথা"
     },
     {
@@ -981,73 +981,73 @@
     {
       "id": "165",
       "district_id": "4",
-      "name": "Gopalganj Sadar Upazila",
+      "name": "Gopalganj Sadar",
       "bn_name": "গোপালগঞ্জ সদর"
     },
     {
       "id": "166",
       "district_id": "4",
-      "name": "Kashiani Upazila",
+      "name": "Kashiani",
       "bn_name": "কাশিয়ানি"
     },
     {
       "id": "167",
       "district_id": "4",
-      "name": "Kotalipara Upazila",
+      "name": "Kotalipara",
       "bn_name": "কোটালিপাড়া"
     },
     {
       "id": "168",
       "district_id": "4",
-      "name": "Muksudpur Upazila",
+      "name": "Muksudpur",
       "bn_name": "মুকসুদপুর"
     },
     {
       "id": "169",
       "district_id": "4",
-      "name": "Tungipara Upazila",
+      "name": "Tungipara",
       "bn_name": "টুঙ্গিপাড়া"
     },
     {
       "id": "170",
       "district_id": "5",
-      "name": "Dewanganj Upazila",
+      "name": "Dewanganj",
       "bn_name": "দেওয়ানগঞ্জ"
     },
     {
       "id": "171",
       "district_id": "5",
-      "name": "Baksiganj Upazila",
+      "name": "Baksiganj",
       "bn_name": "বকসিগঞ্জ"
     },
     {
       "id": "172",
       "district_id": "5",
-      "name": "Islampur Upazila",
+      "name": "Islampur",
       "bn_name": "ইসলামপুর"
     },
     {
       "id": "173",
       "district_id": "5",
-      "name": "Jamalpur Sadar Upazila",
+      "name": "Jamalpur Sadar",
       "bn_name": "জামালপুর সদর"
     },
     {
       "id": "174",
       "district_id": "5",
-      "name": "Madarganj Upazila",
+      "name": "Madarganj",
       "bn_name": "মাদারগঞ্জ"
     },
     {
       "id": "175",
       "district_id": "5",
-      "name": "Melandaha Upazila",
+      "name": "Melandaha",
       "bn_name": "মেলানদাহা"
     },
     {
       "id": "176",
       "district_id": "5",
-      "name": "Sarishabari Upazila",
+      "name": "Sarishabari",
       "bn_name": "সরিষাবাড়ি "
     },
     {
@@ -1059,79 +1059,79 @@
     {
       "id": "178",
       "district_id": "6",
-      "name": "Astagram Upazila",
+      "name": "Astagram",
       "bn_name": "অষ্টগ্রাম"
     },
     {
       "id": "179",
       "district_id": "6",
-      "name": "Bajitpur Upazila",
+      "name": "Bajitpur",
       "bn_name": "বাজিতপুর"
     },
     {
       "id": "180",
       "district_id": "6",
-      "name": "Bhairab Upazila",
+      "name": "Bhairab",
       "bn_name": "ভৈরব"
     },
     {
       "id": "181",
       "district_id": "6",
-      "name": "Hossainpur Upazila",
+      "name": "Hossainpur",
       "bn_name": "হোসেনপুর "
     },
     {
       "id": "182",
       "district_id": "6",
-      "name": "Itna Upazila",
+      "name": "Itna",
       "bn_name": "ইটনা"
     },
     {
       "id": "183",
       "district_id": "6",
-      "name": "Karimganj Upazila",
+      "name": "Karimganj",
       "bn_name": "করিমগঞ্জ"
     },
     {
       "id": "184",
       "district_id": "6",
-      "name": "Katiadi Upazila",
+      "name": "Katiadi",
       "bn_name": "কতিয়াদি"
     },
     {
       "id": "185",
       "district_id": "6",
-      "name": "Kishoreganj Sadar Upazila",
+      "name": "Kishoreganj Sadar",
       "bn_name": "কিশোরগঞ্জ সদর"
     },
     {
       "id": "186",
       "district_id": "6",
-      "name": "Kuliarchar Upazila",
+      "name": "Kuliarchar",
       "bn_name": "কুলিয়ারচর"
     },
     {
       "id": "187",
       "district_id": "6",
-      "name": "Mithamain Upazila",
+      "name": "Mithamain",
       "bn_name": "মিঠামাইন"
     },
     {
       "id": "188",
       "district_id": "6",
-      "name": "Nikli Upazila",
+      "name": "Nikli",
       "bn_name": "নিকলি"
     },
     {
       "id": "189",
       "district_id": "6",
-      "name": "Pakundia Upazila",
+      "name": "Pakundia",
       "bn_name": "পাকুন্ডা"
     },
     {
       "id": "190",
       "district_id": "6",
-      "name": "Tarail Upazila",
+      "name": "Tarail",
       "bn_name": "তাড়াইল"
     },
     {
@@ -1161,79 +1161,79 @@
     {
       "id": "195",
       "district_id": "8",
-      "name": "Manikganj Sadar Upazila",
+      "name": "Manikganj Sadar",
       "bn_name": "মানিকগঞ্জ সদর"
     },
     {
       "id": "196",
       "district_id": "8",
-      "name": "Singair Upazila",
+      "name": "Singair",
       "bn_name": "সিঙ্গাইর"
     },
     {
       "id": "197",
       "district_id": "8",
-      "name": "Shibalaya Upazila",
+      "name": "Shibalaya",
       "bn_name": "শিবালয়"
     },
     {
       "id": "198",
       "district_id": "8",
-      "name": "Saturia Upazila",
+      "name": "Saturia",
       "bn_name": "সাঠুরিয়া"
     },
     {
       "id": "199",
       "district_id": "8",
-      "name": "Harirampur Upazila",
+      "name": "Harirampur",
       "bn_name": "হরিরামপুর"
     },
     {
       "id": "200",
       "district_id": "8",
-      "name": "Ghior Upazila",
+      "name": "Ghior",
       "bn_name": "ঘিওর"
     },
     {
       "id": "201",
       "district_id": "8",
-      "name": "Daulatpur Upazila",
+      "name": "Daulatpur",
       "bn_name": "দৌলতপুর"
     },
     {
       "id": "202",
       "district_id": "9",
-      "name": "Lohajang Upazila",
+      "name": "Lohajang",
       "bn_name": "লোহাজং"
     },
     {
       "id": "203",
       "district_id": "9",
-      "name": "Sreenagar Upazila",
+      "name": "Sreenagar",
       "bn_name": "শ্রীনগর"
     },
     {
       "id": "204",
       "district_id": "9",
-      "name": "Munshiganj Sadar Upazila",
+      "name": "Munshiganj Sadar",
       "bn_name": "মুন্সিগঞ্জ সদর"
     },
     {
       "id": "205",
       "district_id": "9",
-      "name": "Sirajdikhan Upazila",
+      "name": "Sirajdikhan",
       "bn_name": "সিরাজদিখান"
     },
     {
       "id": "206",
       "district_id": "9",
-      "name": "Tongibari Upazila",
+      "name": "Tongibari",
       "bn_name": "টঙ্গিবাড়ি"
     },
     {
       "id": "207",
       "district_id": "9",
-      "name": "Gazaria Upazila",
+      "name": "Gazaria",
       "bn_name": "গজারিয়া"
     },
     {
@@ -1311,13 +1311,13 @@
     {
       "id": "220",
       "district_id": "11",
-      "name": "Araihazar Upazila",
+      "name": "Araihazar",
       "bn_name": "আড়াইহাজার"
     },
     {
       "id": "221",
       "district_id": "11",
-      "name": "Sonargaon Upazila",
+      "name": "Sonargaon",
       "bn_name": "সোনারগাঁও"
     },
     {
@@ -1329,55 +1329,55 @@
     {
       "id": "223",
       "district_id": "11",
-      "name": "Naryanganj Sadar Upazila",
+      "name": "Naryanganj Sadar",
       "bn_name": "নারায়ানগঞ্জ সদর"
     },
     {
       "id": "224",
       "district_id": "11",
-      "name": "Rupganj Upazila",
+      "name": "Rupganj",
       "bn_name": "রূপগঞ্জ"
     },
     {
       "id": "225",
       "district_id": "11",
-      "name": "Siddirgonj Upazila",
+      "name": "Siddirgonj",
       "bn_name": "সিদ্ধিরগঞ্জ"
     },
     {
       "id": "226",
       "district_id": "12",
-      "name": "Belabo Upazila",
+      "name": "Belabo",
       "bn_name": "বেলাবো"
     },
     {
       "id": "227",
       "district_id": "12",
-      "name": "Monohardi Upazila",
+      "name": "Monohardi",
       "bn_name": "মনোহরদি"
     },
     {
       "id": "228",
       "district_id": "12",
-      "name": "Narsingdi Sadar Upazila",
+      "name": "Narsingdi Sadar",
       "bn_name": "নরসিংদী সদর"
     },
     {
       "id": "229",
       "district_id": "12",
-      "name": "Palash Upazila",
+      "name": "Palash",
       "bn_name": "পলাশ"
     },
     {
       "id": "230",
       "district_id": "12",
-      "name": "Raipura Upazila, Narsingdi",
+      "name": "Raipura, Narsingdi",
       "bn_name": "রায়পুর"
     },
     {
       "id": "231",
       "district_id": "12",
-      "name": "Shibpur Upazila",
+      "name": "Shibpur",
       "bn_name": "শিবপুর"
     },
     {
@@ -1443,31 +1443,31 @@
     {
       "id": "242",
       "district_id": "14",
-      "name": "Baliakandi Upazila",
+      "name": "Baliakandi",
       "bn_name": "বালিয়াকান্দি"
     },
     {
       "id": "243",
       "district_id": "14",
-      "name": "Goalandaghat Upazila",
+      "name": "Goalandaghat",
       "bn_name": "গোয়ালন্দ ঘাট"
     },
     {
       "id": "244",
       "district_id": "14",
-      "name": "Pangsha Upazila",
+      "name": "Pangsha",
       "bn_name": "পাংশা"
     },
     {
       "id": "245",
       "district_id": "14",
-      "name": "Kalukhali Upazila",
+      "name": "Kalukhali",
       "bn_name": "কালুখালি"
     },
     {
       "id": "246",
       "district_id": "14",
-      "name": "Rajbari Sadar Upazila",
+      "name": "Rajbari Sadar",
       "bn_name": "রাজবাড়ি সদর"
     },
     {
@@ -1479,349 +1479,349 @@
     {
       "id": "248",
       "district_id": "15",
-      "name": "Damudya Upazila",
+      "name": "Damudya",
       "bn_name": "দামুদিয়া"
     },
     {
       "id": "249",
       "district_id": "15",
-      "name": "Naria Upazila",
+      "name": "Naria",
       "bn_name": "নড়িয়া"
     },
     {
       "id": "250",
       "district_id": "15",
-      "name": "Jajira Upazila",
+      "name": "Jajira",
       "bn_name": "জাজিরা"
     },
     {
       "id": "251",
       "district_id": "15",
-      "name": "Bhedarganj Upazila",
+      "name": "Bhedarganj",
       "bn_name": "ভেদারগঞ্জ"
     },
     {
       "id": "252",
       "district_id": "15",
-      "name": "Gosairhat Upazila",
+      "name": "Gosairhat",
       "bn_name": "গোসাইর হাট "
     },
     {
       "id": "253",
       "district_id": "16",
-      "name": "Jhenaigati Upazila",
+      "name": "Jhenaigati",
       "bn_name": "ঝিনাইগাতি"
     },
     {
       "id": "254",
       "district_id": "16",
-      "name": "Nakla Upazila",
+      "name": "Nakla",
       "bn_name": "নাকলা"
     },
     {
       "id": "255",
       "district_id": "16",
-      "name": "Nalitabari Upazila",
+      "name": "Nalitabari",
       "bn_name": "নালিতাবাড়ি"
     },
     {
       "id": "256",
       "district_id": "16",
-      "name": "Sherpur Sadar Upazila",
+      "name": "Sherpur Sadar",
       "bn_name": "শেরপুর সদর"
     },
     {
       "id": "257",
       "district_id": "16",
-      "name": "Sreebardi Upazila",
+      "name": "Sreebardi",
       "bn_name": "শ্রীবরদি"
     },
     {
       "id": "258",
       "district_id": "17",
-      "name": "Tangail Sadar Upazila",
+      "name": "Tangail Sadar",
       "bn_name": "টাঙ্গাইল সদর"
     },
     {
       "id": "259",
       "district_id": "17",
-      "name": "Sakhipur Upazila",
+      "name": "Sakhipur",
       "bn_name": "সখিপুর"
     },
     {
       "id": "260",
       "district_id": "17",
-      "name": "Basail Upazila",
+      "name": "Basail",
       "bn_name": "বসাইল"
     },
     {
       "id": "261",
       "district_id": "17",
-      "name": "Madhupur Upazila",
+      "name": "Madhupur",
       "bn_name": "মধুপুর"
     },
     {
       "id": "262",
       "district_id": "17",
-      "name": "Ghatail Upazila",
+      "name": "Ghatail",
       "bn_name": "ঘাটাইল"
     },
     {
       "id": "263",
       "district_id": "17",
-      "name": "Kalihati Upazila",
+      "name": "Kalihati",
       "bn_name": "কালিহাতি"
     },
     {
       "id": "264",
       "district_id": "17",
-      "name": "Nagarpur Upazila",
+      "name": "Nagarpur",
       "bn_name": "নগরপুর"
     },
     {
       "id": "265",
       "district_id": "17",
-      "name": "Mirzapur Upazila",
+      "name": "Mirzapur",
       "bn_name": "মির্জাপুর"
     },
     {
       "id": "266",
       "district_id": "17",
-      "name": "Gopalpur Upazila",
+      "name": "Gopalpur",
       "bn_name": "গোপালপুর"
     },
     {
       "id": "267",
       "district_id": "17",
-      "name": "Delduar Upazila",
+      "name": "Delduar",
       "bn_name": "দেলদুয়ার"
     },
     {
       "id": "268",
       "district_id": "17",
-      "name": "Bhuapur Upazila",
+      "name": "Bhuapur",
       "bn_name": "ভুয়াপুর"
     },
     {
       "id": "269",
       "district_id": "17",
-      "name": "Dhanbari Upazila",
+      "name": "Dhanbari",
       "bn_name": "ধানবাড়ি"
     },
     {
       "id": "270",
       "district_id": "55",
-      "name": "Bagerhat Sadar Upazila",
+      "name": "Bagerhat Sadar",
       "bn_name": "বাগেরহাট সদর"
     },
     {
       "id": "271",
       "district_id": "55",
-      "name": "Chitalmari Upazila",
+      "name": "Chitalmari",
       "bn_name": "চিতলমাড়ি"
     },
     {
       "id": "272",
       "district_id": "55",
-      "name": "Fakirhat Upazila",
+      "name": "Fakirhat",
       "bn_name": "ফকিরহাট"
     },
     {
       "id": "273",
       "district_id": "55",
-      "name": "Kachua Upazila",
+      "name": "Kachua",
       "bn_name": "কচুয়া"
     },
     {
       "id": "274",
       "district_id": "55",
-      "name": "Mollahat Upazila",
+      "name": "Mollahat",
       "bn_name": "মোল্লাহাট "
     },
     {
       "id": "275",
       "district_id": "55",
-      "name": "Mongla Upazila",
+      "name": "Mongla",
       "bn_name": "মংলা"
     },
     {
       "id": "276",
       "district_id": "55",
-      "name": "Morrelganj Upazila",
+      "name": "Morrelganj",
       "bn_name": "মরেলগঞ্জ"
     },
     {
       "id": "277",
       "district_id": "55",
-      "name": "Rampal Upazila",
+      "name": "Rampal",
       "bn_name": "রামপাল"
     },
     {
       "id": "278",
       "district_id": "55",
-      "name": "Sarankhola Upazila",
+      "name": "Sarankhola",
       "bn_name": "স্মরণখোলা"
     },
     {
       "id": "279",
       "district_id": "56",
-      "name": "Damurhuda Upazila",
+      "name": "Damurhuda",
       "bn_name": "দামুরহুদা"
     },
     {
       "id": "280",
       "district_id": "56",
-      "name": "Chuadanga-S Upazila",
+      "name": "Chuadanga-S",
       "bn_name": "চুয়াডাঙ্গা সদর"
     },
     {
       "id": "281",
       "district_id": "56",
-      "name": "Jibannagar Upazila",
+      "name": "Jibannagar",
       "bn_name": "জীবন নগর "
     },
     {
       "id": "282",
       "district_id": "56",
-      "name": "Alamdanga Upazila",
+      "name": "Alamdanga",
       "bn_name": "আলমডাঙ্গা"
     },
     {
       "id": "283",
       "district_id": "57",
-      "name": "Abhaynagar Upazila",
+      "name": "Abhaynagar",
       "bn_name": "অভয়নগর"
     },
     {
       "id": "284",
       "district_id": "57",
-      "name": "Keshabpur Upazila",
+      "name": "Keshabpur",
       "bn_name": "কেশবপুর"
     },
     {
       "id": "285",
       "district_id": "57",
-      "name": "Bagherpara Upazila",
+      "name": "Bagherpara",
       "bn_name": "বাঘের পাড়া "
     },
     {
       "id": "286",
       "district_id": "57",
-      "name": "Jessore Sadar Upazila",
+      "name": "Jessore Sadar",
       "bn_name": "যশোর সদর"
     },
     {
       "id": "287",
       "district_id": "57",
-      "name": "Chaugachha Upazila",
+      "name": "Chaugachha",
       "bn_name": "চৌগাছা"
     },
     {
       "id": "288",
       "district_id": "57",
-      "name": "Manirampur Upazila",
+      "name": "Manirampur",
       "bn_name": "মনিরামপুর "
     },
     {
       "id": "289",
       "district_id": "57",
-      "name": "Jhikargachha Upazila",
+      "name": "Jhikargachha",
       "bn_name": "ঝিকরগাছা"
     },
     {
       "id": "290",
       "district_id": "57",
-      "name": "Sharsha Upazila",
+      "name": "Sharsha",
       "bn_name": "সারশা"
     },
     {
       "id": "291",
       "district_id": "58",
-      "name": "Jhenaidah Sadar Upazila",
+      "name": "Jhenaidah Sadar",
       "bn_name": "ঝিনাইদহ সদর"
     },
     {
       "id": "292",
       "district_id": "58",
-      "name": "Maheshpur Upazila",
+      "name": "Maheshpur",
       "bn_name": "মহেশপুর"
     },
     {
       "id": "293",
       "district_id": "58",
-      "name": "Kaliganj Upazila",
+      "name": "Kaliganj",
       "bn_name": "কালীগঞ্জ"
     },
     {
       "id": "294",
       "district_id": "58",
-      "name": "Kotchandpur Upazila",
+      "name": "Kotchandpur",
       "bn_name": "কোট চাঁদপুর "
     },
     {
       "id": "295",
       "district_id": "58",
-      "name": "Shailkupa Upazila",
+      "name": "Shailkupa",
       "bn_name": "শৈলকুপা"
     },
     {
       "id": "296",
       "district_id": "58",
-      "name": "Harinakunda Upazila",
+      "name": "Harinakunda",
       "bn_name": "হাড়িনাকুন্দা"
     },
     {
       "id": "297",
       "district_id": "59",
-      "name": "Terokhada Upazila",
+      "name": "Terokhada",
       "bn_name": "তেরোখাদা"
     },
     {
       "id": "298",
       "district_id": "59",
-      "name": "Batiaghata Upazila",
+      "name": "Batiaghata",
       "bn_name": "বাটিয়াঘাটা "
     },
     {
       "id": "299",
       "district_id": "59",
-      "name": "Dacope Upazila",
+      "name": "Dacope",
       "bn_name": "ডাকপে"
     },
     {
       "id": "300",
       "district_id": "59",
-      "name": "Dumuria Upazila",
+      "name": "Dumuria",
       "bn_name": "ডুমুরিয়া"
     },
     {
       "id": "301",
       "district_id": "59",
-      "name": "Dighalia Upazila",
+      "name": "Dighalia",
       "bn_name": "দিঘলিয়া"
     },
     {
       "id": "302",
       "district_id": "59",
-      "name": "Koyra Upazila",
+      "name": "Koyra",
       "bn_name": "কয়ড়া"
     },
     {
       "id": "303",
       "district_id": "59",
-      "name": "Paikgachha Upazila",
+      "name": "Paikgachha",
       "bn_name": "পাইকগাছা"
     },
     {
       "id": "304",
       "district_id": "59",
-      "name": "Phultala Upazila",
+      "name": "Phultala",
       "bn_name": "ফুলতলা"
     },
     {
       "id": "305",
       "district_id": "59",
-      "name": "Rupsa Upazila",
+      "name": "Rupsa",
       "bn_name": "রূপসা"
     },
     {
@@ -1863,43 +1863,43 @@
     {
       "id": "312",
       "district_id": "61",
-      "name": "Magura Sadar Upazila",
+      "name": "Magura Sadar",
       "bn_name": "মাগুরা সদর"
     },
     {
       "id": "313",
       "district_id": "61",
-      "name": "Mohammadpur Upazila",
+      "name": "Mohammadpur",
       "bn_name": "মোহাম্মাদপুর"
     },
     {
       "id": "314",
       "district_id": "61",
-      "name": "Shalikha Upazila",
+      "name": "Shalikha",
       "bn_name": "শালিখা"
     },
     {
       "id": "315",
       "district_id": "61",
-      "name": "Sreepur Upazila",
+      "name": "Sreepur",
       "bn_name": "শ্রীপুর"
     },
     {
       "id": "316",
       "district_id": "62",
-      "name": "angni Upazila",
+      "name": "angni",
       "bn_name": "আংনি"
     },
     {
       "id": "317",
       "district_id": "62",
-      "name": "Mujib Nagar Upazila",
+      "name": "Mujib Nagar",
       "bn_name": "মুজিব নগর"
     },
     {
       "id": "318",
       "district_id": "62",
-      "name": "Meherpur-S Upazila",
+      "name": "Meherpur-S",
       "bn_name": "মেহেরপুর সদর"
     },
     {
@@ -1923,43 +1923,43 @@
     {
       "id": "322",
       "district_id": "64",
-      "name": "Satkhira Sadar Upazila",
+      "name": "Satkhira Sadar",
       "bn_name": "সাতক্ষীরা সদর"
     },
     {
       "id": "323",
       "district_id": "64",
-      "name": "Assasuni Upazila",
+      "name": "Assasuni",
       "bn_name": "আসসাশুনি "
     },
     {
       "id": "324",
       "district_id": "64",
-      "name": "Debhata Upazila",
+      "name": "Debhata",
       "bn_name": "দেভাটা"
     },
     {
       "id": "325",
       "district_id": "64",
-      "name": "Tala Upazila",
+      "name": "Tala",
       "bn_name": "তালা"
     },
     {
       "id": "326",
       "district_id": "64",
-      "name": "Kalaroa Upazila",
+      "name": "Kalaroa",
       "bn_name": "কলরোয়া"
     },
     {
       "id": "327",
       "district_id": "64",
-      "name": "Kaliganj Upazila",
+      "name": "Kaliganj",
       "bn_name": "কালীগঞ্জ"
     },
     {
       "id": "328",
       "district_id": "64",
-      "name": "Shyamnagar Upazila",
+      "name": "Shyamnagar",
       "bn_name": "শ্যামনগর"
     },
     {
@@ -2067,187 +2067,187 @@
     {
       "id": "346",
       "district_id": "20",
-      "name": "Naogaon Sadar Upazila",
+      "name": "Naogaon Sadar",
       "bn_name": "নওগাঁ সদর"
     },
     {
       "id": "347",
       "district_id": "20",
-      "name": "Mohadevpur Upazila",
+      "name": "Mohadevpur",
       "bn_name": "মহাদেবপুর"
     },
     {
       "id": "348",
       "district_id": "20",
-      "name": "Manda Upazila",
+      "name": "Manda",
       "bn_name": "মান্দা"
     },
     {
       "id": "349",
       "district_id": "20",
-      "name": "Niamatpur Upazila",
+      "name": "Niamatpur",
       "bn_name": "নিয়ামতপুর"
     },
     {
       "id": "350",
       "district_id": "20",
-      "name": "Atrai Upazila",
+      "name": "Atrai",
       "bn_name": "আত্রাই"
     },
     {
       "id": "351",
       "district_id": "20",
-      "name": "Raninagar Upazila",
+      "name": "Raninagar",
       "bn_name": "রাণীনগর"
     },
     {
       "id": "352",
       "district_id": "20",
-      "name": "Patnitala Upazila",
+      "name": "Patnitala",
       "bn_name": "পত্নীতলা"
     },
     {
       "id": "353",
       "district_id": "20",
-      "name": "Dhamoirhat Upazila",
+      "name": "Dhamoirhat",
       "bn_name": "ধামইরহাট "
     },
     {
       "id": "354",
       "district_id": "20",
-      "name": "Sapahar Upazila",
+      "name": "Sapahar",
       "bn_name": "সাপাহার"
     },
     {
       "id": "355",
       "district_id": "20",
-      "name": "Porsha Upazila",
+      "name": "Porsha",
       "bn_name": "পোরশা"
     },
     {
       "id": "356",
       "district_id": "20",
-      "name": "Badalgachhi Upazila",
+      "name": "Badalgachhi",
       "bn_name": "বদলগাছি"
     },
     {
       "id": "357",
       "district_id": "21",
-      "name": "Natore Sadar Upazila",
+      "name": "Natore Sadar",
       "bn_name": "নাটোর সদর"
     },
     {
       "id": "358",
       "district_id": "21",
-      "name": "Baraigram Upazila",
+      "name": "Baraigram",
       "bn_name": "বড়াইগ্রাম"
     },
     {
       "id": "359",
       "district_id": "21",
-      "name": "Bagatipara Upazila",
+      "name": "Bagatipara",
       "bn_name": "বাগাতিপাড়া"
     },
     {
       "id": "360",
       "district_id": "21",
-      "name": "Lalpur Upazila",
+      "name": "Lalpur",
       "bn_name": "লালপুর"
     },
     {
       "id": "361",
       "district_id": "21",
-      "name": "Natore Sadar Upazila",
+      "name": "Natore Sadar",
       "bn_name": "নাটোর সদর"
     },
     {
       "id": "362",
       "district_id": "21",
-      "name": "Baraigram Upazila",
+      "name": "Baraigram",
       "bn_name": "বড়াই গ্রাম"
     },
     {
       "id": "363",
       "district_id": "22",
-      "name": "Bholahat Upazila",
+      "name": "Bholahat",
       "bn_name": "ভোলাহাট"
     },
     {
       "id": "364",
       "district_id": "22",
-      "name": "Gomastapur Upazila",
+      "name": "Gomastapur",
       "bn_name": "গোমস্তাপুর"
     },
     {
       "id": "365",
       "district_id": "22",
-      "name": "Nachole Upazila",
+      "name": "Nachole",
       "bn_name": "নাচোল"
     },
     {
       "id": "366",
       "district_id": "22",
-      "name": "Nawabganj Sadar Upazila",
+      "name": "Nawabganj Sadar",
       "bn_name": "নবাবগঞ্জ সদর"
     },
     {
       "id": "367",
       "district_id": "22",
-      "name": "Shibganj Upazila",
+      "name": "Shibganj",
       "bn_name": "শিবগঞ্জ"
     },
     {
       "id": "368",
       "district_id": "23",
-      "name": "Atgharia Upazila",
+      "name": "Atgharia",
       "bn_name": "আটঘরিয়া"
     },
     {
       "id": "369",
       "district_id": "23",
-      "name": "Bera Upazila",
+      "name": "Bera",
       "bn_name": "বেড়া"
     },
     {
       "id": "370",
       "district_id": "23",
-      "name": "Bhangura Upazila",
+      "name": "Bhangura",
       "bn_name": "ভাঙ্গুরা"
     },
     {
       "id": "371",
       "district_id": "23",
-      "name": "Chatmohar Upazila",
+      "name": "Chatmohar",
       "bn_name": "চাটমোহর"
     },
     {
       "id": "372",
       "district_id": "23",
-      "name": "Faridpur Upazila",
+      "name": "Faridpur",
       "bn_name": "ফরিদপুর"
     },
     {
       "id": "373",
       "district_id": "23",
-      "name": "Ishwardi Upazila",
+      "name": "Ishwardi",
       "bn_name": "ঈশ্বরদী"
     },
     {
       "id": "374",
       "district_id": "23",
-      "name": "Pabna Sadar Upazila",
+      "name": "Pabna Sadar",
       "bn_name": "পাবনা সদর"
     },
     {
       "id": "375",
       "district_id": "23",
-      "name": "Santhia Upazila",
+      "name": "Santhia",
       "bn_name": "সাথিয়া"
     },
     {
       "id": "376",
       "district_id": "23",
-      "name": "Sujanagar Upazila",
+      "name": "Sujanagar",
       "bn_name": "সুজানগর"
     },
     {
@@ -2307,61 +2307,61 @@
     {
       "id": "386",
       "district_id": "25",
-      "name": "Sirajganj Sadar Upazila",
+      "name": "Sirajganj Sadar",
       "bn_name": "সিরাজগঞ্জ সদর"
     },
     {
       "id": "387",
       "district_id": "25",
-      "name": "Belkuchi Upazila",
+      "name": "Belkuchi",
       "bn_name": "বেলকুচি"
     },
     {
       "id": "388",
       "district_id": "25",
-      "name": "Chauhali Upazila",
+      "name": "Chauhali",
       "bn_name": "চৌহালি"
     },
     {
       "id": "389",
       "district_id": "25",
-      "name": "Kamarkhanda Upazila",
+      "name": "Kamarkhanda",
       "bn_name": "কামারখান্দা"
     },
     {
       "id": "390",
       "district_id": "25",
-      "name": "Kazipur Upazila",
+      "name": "Kazipur",
       "bn_name": "কাজীপুর"
     },
     {
       "id": "391",
       "district_id": "25",
-      "name": "Raiganj Upazila",
+      "name": "Raiganj",
       "bn_name": "রায়গঞ্জ"
     },
     {
       "id": "392",
       "district_id": "25",
-      "name": "Shahjadpur Upazila",
+      "name": "Shahjadpur",
       "bn_name": "শাহজাদপুর"
     },
     {
       "id": "393",
       "district_id": "25",
-      "name": "Tarash Upazila",
+      "name": "Tarash",
       "bn_name": "তারাশ"
     },
     {
       "id": "394",
       "district_id": "25",
-      "name": "Ullahpara Upazila",
+      "name": "Ullahpara",
       "bn_name": "উল্লাপাড়া"
     },
     {
       "id": "395",
       "district_id": "26",
-      "name": "Birampur Upazila",
+      "name": "Birampur",
       "bn_name": "বিরামপুর"
     },
     {
@@ -2373,55 +2373,55 @@
     {
       "id": "397",
       "district_id": "26",
-      "name": "Biral Upazila",
+      "name": "Biral",
       "bn_name": "বিড়াল"
     },
     {
       "id": "398",
       "district_id": "26",
-      "name": "Bochaganj Upazila",
+      "name": "Bochaganj",
       "bn_name": "বোচাগঞ্জ"
     },
     {
       "id": "399",
       "district_id": "26",
-      "name": "Chirirbandar Upazila",
+      "name": "Chirirbandar",
       "bn_name": "চিরিরবন্দর"
     },
     {
       "id": "400",
       "district_id": "26",
-      "name": "Phulbari Upazila",
+      "name": "Phulbari",
       "bn_name": "ফুলবাড়ি"
     },
     {
       "id": "401",
       "district_id": "26",
-      "name": "Ghoraghat Upazila",
+      "name": "Ghoraghat",
       "bn_name": "ঘোড়াঘাট"
     },
     {
       "id": "402",
       "district_id": "26",
-      "name": "Hakimpur Upazila",
+      "name": "Hakimpur",
       "bn_name": "হাকিমপুর"
     },
     {
       "id": "403",
       "district_id": "26",
-      "name": "Kaharole Upazila",
+      "name": "Kaharole",
       "bn_name": "কাহারোল"
     },
     {
       "id": "404",
       "district_id": "26",
-      "name": "Khansama Upazila",
+      "name": "Khansama",
       "bn_name": "খানসামা"
     },
     {
       "id": "405",
       "district_id": "26",
-      "name": "Dinajpur Sadar Upazila",
+      "name": "Dinajpur Sadar",
       "bn_name": "দিনাজপুর সদর"
     },
     {
@@ -2433,7 +2433,7 @@
     {
       "id": "407",
       "district_id": "26",
-      "name": "Parbatipur Upazila",
+      "name": "Parbatipur",
       "bn_name": "পার্বতীপুর"
     },
     {
@@ -2679,31 +2679,31 @@
     {
       "id": "448",
       "district_id": "33",
-      "name": "Thakurgaon Sadar Upazila",
+      "name": "Thakurgaon Sadar",
       "bn_name": "ঠাকুরগাঁও সদর"
     },
     {
       "id": "449",
       "district_id": "33",
-      "name": "Pirganj Upazila",
+      "name": "Pirganj",
       "bn_name": "পীরগঞ্জ"
     },
     {
       "id": "450",
       "district_id": "33",
-      "name": "Baliadangi Upazila",
+      "name": "Baliadangi",
       "bn_name": "বালিয়াডাঙ্গি"
     },
     {
       "id": "451",
       "district_id": "33",
-      "name": "Haripur Upazila",
+      "name": "Haripur",
       "bn_name": "হরিপুর"
     },
     {
       "id": "452",
       "district_id": "33",
-      "name": "Ranisankail Upazila",
+      "name": "Ranisankail",
       "bn_name": "রাণীসংকইল"
     },
     {
@@ -2757,7 +2757,7 @@
     {
       "id": "461",
       "district_id": "51",
-      "name": "Shaistagonj Upazila",
+      "name": "Shaistagonj",
       "bn_name": "শায়েস্তাগঞ্জ"
     },
     {
@@ -2889,7 +2889,7 @@
     {
       "id": "483",
       "district_id": "54",
-      "name": "Dakshin Surma Upazila",
+      "name": "Dakshin Surma",
       "bn_name": "দক্ষিণ সুরমা"
     },
     {


### PR DESCRIPTION
Some of them had them, some of them didn't Also bn names don't have the word in it. This PR makes it consistent. 