### PR TITLE
Saturia Upazila typing mistake fixed

### DIFF
--- a/bd-upazilas.json
+++ b/bd-upazilas.json
@@ -1180,7 +1180,7 @@
       "id": "198",
       "district_id": "8",
       "name": "Saturia",
-      "bn_name": "সাঠুরিয়া"
+      "bn_name": "সাটুরিয়া"
     },
     {
       "id": "199",


### PR DESCRIPTION
I've made the upozila name from `সাঠুরিয়া` to `সাটুরিয়া`।

References:
http://saturia.manikganj.gov.bd
https://bn.wikipedia.org/সাটুরিয়া_উপজেলা